### PR TITLE
Bump dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
   },
   "homepage": "https://github.com/Munter/hyperlink",
   "dependencies": {
-    "assetgraph": "1.11.1",
+    "assetgraph": "^1.16.0",
     "async": "^0.9.0",
-    "chalk": "^0.5.0",
-    "lodash": "^2.4.1",
+    "chalk": "^1.0.0",
+    "lodash": "^3.5.0",
     "optimist": "^0.6.1",
     "request": "^2.36.0",
     "urltools": "0.2.0"


### PR DESCRIPTION
That red badge looks really daunting. Upgraded locally and checked manually that it still works as before. 