### PR TITLE
Add `concurrency` option to CLI

### DIFF
--- a/bin/hyperlink
+++ b/bin/hyperlink
@@ -29,6 +29,12 @@ var optimist = require('optimist'),
             describe: 'Crawl all HTML-pages linked with relative and root relative links. This stays inside your domain.',
             type: 'boolean'
         })
+        .options('concurrency', {
+            alias: 'c',
+            describe: 'The maximum number of assets that can be loading at once (defaults to 100)',
+            default: 100,
+            type: 'integer'
+        })
         .wrap(72)
         .argv;
 
@@ -67,5 +73,6 @@ hyperlink({
     root: rootUrl,
     inputUrls: inputUrls,
     recursive: commandLineOptions.recursive,
-    verbose: commandLineOptions.verbose
+    verbose: commandLineOptions.verbose,
+    concurrency: commandLineOptions.concurrency
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -233,7 +233,8 @@ module.exports = function (options) {
 
     ag.loadAssets(options.inputUrls)
         .populate({
-            followRelations: relationsQuery
+            followRelations: relationsQuery,
+            concurrency: options.concurrency || 100
         })
         .queue(function (assetGraph, callback) {
             var hrefMap = {};


### PR DESCRIPTION
This PR adds a `concurrency` option to be passed to assetgraph (as in: https://github.com/assetgraph/assetgraph#concurrency-number). I have had some issues when too many assets loaded at once caused false negatives due to timeout errors.