### PR TITLE
fix(timeout): fix syntax error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -26,7 +26,7 @@ module.exports = function (options) {
         canonicalRoot: options.canonicalRoot
     });
 
-    ag.teepee.headers['User-Agent'] = 'User-Agent': 'Hyperlink v' + version + ' (https://www.npmjs.com/package/hyperlink)';
+    ag.teepee.headers['User-Agent'] = 'Hyperlink v' + version + ' (https://www.npmjs.com/package/hyperlink)';
     ag.teepee.timeout = 30000;
 
     var excludePattern;


### PR DESCRIPTION
The `:` was causing a syntax error to be thrown. It seems that colon and the "User-Agent" bit was unnecessary since the header is already declared as `'User-Agent'`.

@Munter tried this on webpack/webpack.js.org#1582 and got the syntax error. You can check the build there to see what I mean. Happy to try again once the this is merged/resolved.