### PR TITLE
Follow crossorigin relations to assets that will be loaded as part of the page, except HtmlIframe

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -342,13 +342,13 @@ module.exports = async function ({
                     follow = false;
                     relation.to['check' + relation.type] = true;
                 } else if (['HtmlAnchor', 'SvgAnchor', 'HtmlIFrame'].includes(relation.type)) {
-                    if (!relation.crossorigin && options.recursive) {
+                    if (!relation.crossorigin && recursive) {
                         follow = true;
                     } else {
                         relation.to.check = true;
                     }
                 } else if (['SourceMapFile', 'SourceMapSource'].includes(relation.type)) {
-                    if (options.followSourceMaps) {
+                    if (followSourceMaps) {
                         follow = true;
                     } else {
                         relation.to.check = true;

--- a/lib/index.js
+++ b/lib/index.js
@@ -323,14 +323,24 @@ module.exports = async function ({
                 }
 
                 // Check for mixed-content warning:
-                if (!['HtmlAnchor', 'SvgAnchor'].includes(relation.type)) {
+                if (relation.type === 'HttpRedirect' && relation.from.nonInlineAncestor.protocol === 'https:' && relation.to.protocol === 'http:') {
+                    t.push(null, {
+                        ok: false,
+                        skip: shouldSkip(relation.to.url),
+                        name: `URI should be secure - ${relation.to.url}`,
+                        operator: 'mixed-content',
+                        expected: `${relation.from.urlOrDescription} --> ${relation.to.url.replace(/\bhttps?:/g, 'https:')}`,
+                        actual: `${relation.from.urlOrDescription} --> ${relation.to.url}`,
+                        at: relationDebugDescription(relation)
+                    });
+                } else if (!['HtmlAnchor', 'SvgAnchor'].includes(relation.type)) {
                     if (asset.protocol === 'https:' && relation.to.protocol === 'http:') {
                         t.push(null, {
                             ok: false,
                             skip: shouldSkip(relation.to.url),
                             name: `URI should be secure - ${relation.to.url}`,
                             operator: 'mixed-content',
-                            expected: relation.to.url.replace(/\bhttps?:/g, 'https:'),
+                            expected: relation.to.nonInlineAncestor.url.replace(/\bhttps?:/g, 'https:'),
                             actual: relation.to.url,
                             at: relationDebugDescription(relation)
                         });

--- a/lib/index.js
+++ b/lib/index.js
@@ -41,19 +41,6 @@ module.exports = async function (options, t) {
         return false;
     }
 
-    const relationTypeExclusions = [
-        'HtmlPreconnectLink',
-        'HtmlDnsPrefetchLink'
-    ];
-
-    if (!options.recursive) {
-        relationTypeExclusions.push('HtmlAnchor', 'SvgAnchor');
-    }
-
-    if (!options.followSourceMaps) {
-        relationTypeExclusions.push('SourceMapFile', 'SourceMapSource');
-    }
-
     function logResult(status, url, redirects, incoming) {
         redirects = redirects || [];
         incoming = incoming || [];
@@ -118,45 +105,6 @@ module.exports = async function (options, t) {
             }
 
             t.push(null, report);
-        }
-
-        // Check for mixed-content warnings
-        const secureSourceRelations = incoming.filter(
-            relation => relation.type !== 'HtmlAnchor' && relation.fromProtocol
-        );
-
-        if (secureSourceRelations.length > 0) {
-            const hasSecureTarget = /^(?:https:)?\/\//.test(url) && redirects.every(
-                redirect => /^(?:https:)?\/\//.test(redirect.redirectUri)
-            );
-
-            if (!hasSecureTarget) {
-                const insecureLog = [{ redirectUri: url }, ...redirects].map((item, idx, arr) => {
-                    if (arr[idx + 1]) {
-                        item.statusCode = arr[idx + 1].statusCode;
-                    } else {
-                        item.statusCode = 200;
-                    }
-
-                    return item;
-                });
-
-                const insecureLogLine = insecureLog.map(
-                    redirect => redirect.redirectUri
-                ).join(' --> ');
-
-                const insecureReport = {
-                    ok: false,
-                    skip,
-                    name: `URI should be secure - ${url}`,
-                    operator: 'mixed-content',
-                    expected: insecureLogLine.replace(/\bhttps?:/g, 'https:'),
-                    actual: insecureLogLine,
-                    at
-                };
-
-                t.push(null, insecureReport);
-            }
         }
     }
 
@@ -353,25 +301,50 @@ module.exports = async function (options, t) {
                         });
                     }
                 }
-                if (relation.crossorigin && /^https?:/.test(relation.to.protocol)) {
-                    if (relation.type === 'HtmlPreconnectLink') {
-                        relation.to.checkPreconnect = true;
-                    } else if (relation.type === 'HtmlDnsPrefetchLink') {
-                        relation.to.checkDnsPrefetch = true;
-                    } else {
-                        relation.to.check = true;
-                    }
-                }
                 if (!relation.to._incoming) {
                     (relation.to._incoming = relation.to._incoming || []).push(
                         {
                             type: relation.type,
-                            fromProtocol: relation.from.nonInlineAncestor.protocol === 'https:',
                             debugDescription: relationDebugDescription(relation)
                         }
                     );
                 }
-                if (!relation.crossorigin && !relationTypeExclusions.includes(relation.type)) {
+
+                // Check for mixed-content warning:
+                if (!['HtmlAnchor', 'SvgAnchor'].includes(relation.type)) {
+                    if (asset.protocol === 'https:' && relation.to.protocol === 'http:') {
+                        t.push(null, {
+                            ok: false,
+                            skip: shouldSkip(relation.to.url),
+                            name: `URI should be secure - ${relation.to.url}`,
+                            operator: 'mixed-content',
+                            expected: relation.to.url.replace(/\bhttps?:/g, 'https:'),
+                            actual: relation.to.url,
+                            at: relationDebugDescription(relation)
+                        });
+                    }
+                }
+
+                let follow;
+                if (['HtmlPreconnectLink', 'HtmlDnsPrefetchLink'].includes(relation.type)) {
+                    follow = false;
+                    relation.to['check' + relation.type] = true;
+                } else if (['HtmlAnchor', 'SvgAnchor', 'HtmlIFrame'].includes(relation.type)) {
+                    if (!relation.crossorigin && options.recursive) {
+                        follow = true;
+                    } else {
+                        relation.to.check = true;
+                    }
+                } else if (['SourceMapFile', 'SourceMapSource'].includes(relation.type)) {
+                    if (options.followSourceMaps) {
+                        follow = true;
+                    } else {
+                        relation.to.check = true;
+                    }
+                } else {
+                    follow = true;
+                }
+                if (follow) {
                     assetQueue.push(relation.to);
                 }
             }
@@ -442,7 +415,7 @@ module.exports = async function (options, t) {
 
     // Check preconnects:
 
-    const preconnectAssetsToCheck = ag.findAssets({checkPreconnect: true});
+    const preconnectAssetsToCheck = ag.findAssets({checkHtmlPreconnectLink: true});
 
     t.push({
         name: `Connecting to ${preconnectAssetsToCheck.length} hosts (checking <link rel="preconnect" href="...">`
@@ -462,7 +435,7 @@ module.exports = async function (options, t) {
 
     // Check dns-prefetches:
 
-    const dnsPrefetchAssetsToCheck = ag.findAssets({checkDnsPrefetch: true});
+    const dnsPrefetchAssetsToCheck = ag.findAssets({checkHtmlDnsPrefetchLink: true});
 
     t.push({
         name: `Looking up ${dnsPrefetchAssetsToCheck.length} host names (checking <link rel="dns-prefetch" href="...">`

--- a/test/index.js
+++ b/test/index.js
@@ -507,11 +507,11 @@ describe('hyperlink', function () {
                         headers: {
                             'Content-Type': 'text/html; charset=UTF-8'
                         },
-                        body: '<html><head></head><body><iframe src="https://elsewhere.com/"></iframe></body></html>'
+                        body: '<html><head></head><body><script src="https://elsewhere.com/"></script></body></html>'
                     }
                 },
                 {
-                    request: 'HEAD https://elsewhere.com/',
+                    request: 'GET https://elsewhere.com/',
                     response: {
                         statusCode: 302,
                         headers: {
@@ -520,7 +520,7 @@ describe('hyperlink', function () {
                     }
                 },
                 {
-                    request: 'HEAD http://elsewhere.com/redirectTarget',
+                    request: 'GET http://elsewhere.com/redirectTarget',
                     response: {
                         statusCode: 302,
                         headers: {
@@ -529,12 +529,13 @@ describe('hyperlink', function () {
                     }
                 },
                 {
-                    request: 'HEAD https://elsewhere.com/redirectTarget',
+                    request: 'GET https://elsewhere.com/redirectTarget',
                     response: {
                         statusCode: 200,
                         headers: {
-                            'Content-Type': 'text/html'
-                        }
+                            'Content-Type': 'application/javascript'
+                        },
+                        body: 'alert("foo");'
                     }
                 }
             ]);
@@ -551,8 +552,8 @@ describe('hyperlink', function () {
                 t.push(null, {
                     ok: false,
                     operator: 'mixed-content',
-                    actual: 'https://elsewhere.com/ --> http://elsewhere.com/redirectTarget --> https://elsewhere.com/redirectTarget',
-                    expected: 'https://elsewhere.com/ --> https://elsewhere.com/redirectTarget --> https://elsewhere.com/redirectTarget'
+                    actual: 'https://elsewhere.com/ --> http://elsewhere.com/redirectTarget',
+                    expected: 'https://elsewhere.com/ --> https://elsewhere.com/redirectTarget'
                 });
             });
         });


### PR DESCRIPTION
The purpose is to detect 404s that would occur during the page load due to errors in the next level(s) of relations.

Moves the mixed content warning check into `processAsset` instead of being a side effect of `logResult`.

Similar to Munter/subfont#15