### PR TITLE
--skip and --todo and deprecate --exclude

### DIFF
--- a/bin/hyperlink
+++ b/bin/hyperlink
@@ -35,7 +35,7 @@ const commandLineOptions = optimist
             default: false
         })
         .options('exclude', {
-            describe: 'Url pattern to exclude from the build. Supports * wildcards. You can create multiple of these: --exclude *.php --exclude http://example.com/*.gif',
+            describe: 'Url pattern to exclude from the build. **THIS OPTION IS DEPRECATED**',
             type: 'string',
             demand: false
         })
@@ -63,6 +63,11 @@ const excludePatterns = commandLineOptions.exclude && [].concat(commandLineOptio
 const followSourceMaps = commandLineOptions['source-maps'];
 let rootUrl = commandLineOptions.root && urlTools.urlOrFsPathToUrl(commandLineOptions.root, true);
 let inputUrls;
+
+if (excludePatterns) {
+    console.error('The --exclude option has been deprecated in hyperlink 4.x');
+    process.exit(1);
+}
 
 if (commandLineOptions._.length > 0) {
     inputUrls = commandLineOptions._.map(function (urlOrFsPath) {
@@ -96,7 +101,6 @@ t.pipe(process.stdout);
             canonicalRoot: canonicalRoot,
             inputUrls: inputUrls,
             followSourceMaps: followSourceMaps,
-            excludePatterns: excludePatterns,
             recursive: commandLineOptions.recursive,
             verbose: commandLineOptions.verbose,
             concurrency: commandLineOptions.concurrency,

--- a/bin/hyperlink
+++ b/bin/hyperlink
@@ -34,6 +34,16 @@ const commandLineOptions = optimist
             type: 'boolean',
             default: false
         })
+        .options('skip', {
+            describe: 'Avoid running a test where the report matches the given pattern',
+            type: 'string',
+            demand: false
+        })
+        .options('todo', {
+            describe: 'Mark a failed tests as todo where the report matches the given pattern',
+            type: 'string',
+            demand: false
+        })
         .options('exclude', {
             describe: 'Url pattern to exclude from the build. **THIS OPTION IS DEPRECATED**',
             type: 'string',
@@ -59,12 +69,13 @@ if (commandLineOptions.h) {
 
 const urlTools = require('urltools');
 const canonicalRoot = commandLineOptions.canonicalroot && urlTools.ensureTrailingSlash(commandLineOptions.canonicalroot);
-const excludePatterns = commandLineOptions.exclude && [].concat(commandLineOptions.exclude);
+const skipPatterns = commandLineOptions.skip && [].concat(commandLineOptions.skip) || [];
+const todoPatterns = commandLineOptions.todo && [].concat(commandLineOptions.todo) || [];
 const followSourceMaps = commandLineOptions['source-maps'];
 let rootUrl = commandLineOptions.root && urlTools.urlOrFsPathToUrl(commandLineOptions.root, true);
 let inputUrls;
 
-if (excludePatterns) {
+if (commandLineOptions.exclude) {
     console.error('The --exclude option has been deprecated in hyperlink 4.x');
     process.exit(1);
 }
@@ -91,6 +102,9 @@ if (commandLineOptions._.length > 0) {
 const TapRender = require('tap-render');
 const hyperlink = require('../lib/index');
 
+const skipFilter = report => Object.values(report).some(value => skipPatterns.some(pattern => String(value).includes(pattern)));
+const todoFilter = report => Object.values(report).some(value => todoPatterns.some(pattern => String(value).includes(pattern)));
+
 const t = new TapRender();
 t.pipe(process.stdout);
 
@@ -102,6 +116,8 @@ t.pipe(process.stdout);
             inputUrls: inputUrls,
             followSourceMaps: followSourceMaps,
             recursive: commandLineOptions.recursive,
+            skipFilter,
+            todoFilter,
             verbose: commandLineOptions.verbose,
             concurrency: commandLineOptions.concurrency,
             memdebug: commandLineOptions.debug

--- a/lib/index.js
+++ b/lib/index.js
@@ -63,8 +63,30 @@ async function hyperlink({
     ag.teepee.headers['User-Agent'] = hyperlinkUserAgent;
     ag.teepee.timeout = 30000;
 
+    function shouldSkip(report) {
+        let skip;
+        try {
+            skip = skipFilter(report);
+        } catch (err) {
+            console.error(err.stack);
+            process.exit();
+        }
+
+        if (skip === true || typeof skip === 'string') {
+            t.push(null, {
+                ...report,
+                skip
+            });
+
+            return true;
+        }
+
+        return false;
+    }
+
     function reportTest(report) {
         const newReport = { ...report };
+
         const todo = todoFilter(report);
 
         if (todo === true || typeof todo === 'string') {
@@ -134,37 +156,45 @@ async function hyperlink({
         }
     }
 
-    function tryConnect(url, incoming, attempt) {
+    function tryConnect(url, incoming, connectionReport) {
         const urlObj = urlModule.parse(url);
         const hostname = urlObj.hostname;
         const isTls = urlObj.protocol === 'https:';
         const port = urlObj.port ? parseInt(urlObj.port, 10) : (isTls ? 443 : 80);
-        attempt = attempt || 1;
+
+        if (shouldSkip(connectionReport)) {
+            return callback => callback(undefined, true);
+        }
+
         return callback => {
             const socket = (isTls ? tls : net).connect(port, hostname, () => {
-                logResult(true, url, undefined, incoming);
+                reportTest({
+                    ...connectionReport,
+                    ok: true
+                });
+
                 socket.destroy();
 
                 callback(undefined, true);
             }).on('error', error => {
                 const code = error.code;
-                let status = false;
-                if (code) {
-                    // Some servers send responses that request apparently handles badly when using the HEAD method...
-                    if (code === 'HPE_INVALID_CONSTANT' && attempt === 1) {
-                        return tryConnect(url, incoming, attempt + 1)(callback);
-                    }
+                const message = error.message;
 
-                    if (code === 'ENOTFOUND') {
-                        status = 'DNS Missing';
-                    } else {
-                        status = code;
-                    }
-                } else {
-                    status = 'Unknown error';
+                let actual;
+
+                switch (code) {
+                    case 'ENOTFOUND':
+                        actual = `DNS missing: ${hostname}`;
+                        break;
+                    default:
+                        actual = message || 'Unknown error';
                 }
 
-                logResult(status, url, undefined, incoming);
+                reportTest({
+                    ...connectionReport,
+                    ok: false,
+                    actual
+                });
 
                 callback(undefined, false);
             });
@@ -304,24 +334,34 @@ async function hyperlink({
     async function processAsset(asset) {
         if (!processedAssets.has(asset)) {
             processedAssets.add(asset);
+            const loadReport = {
+                operator: 'load',
+                name: `load ${asset.urlOrDescription}`
+            };
+
+            if (asset._incoming && asset._incoming[0].debugDescription) {
+                loadReport.at = asset._incoming[0].debugDescription;
+            } else {
+                loadReport.at = `${asset.urlOrDescription} (input URL)`;
+            }
+
+            if (shouldSkip(loadReport)) {
+                return;
+            }
+
             try {
                 await asset.load();
 
                 reportTest({
-                    ok: true,
-                    operator: 'load',
-                    name: `load ${asset.urlOrDescription}`
+                    ...loadReport,
+                    ok: true
                 });
             } catch (err) {
-                const report = {
+                reportTest({
+                    ...loadReport,
                     ok: false,
-                    operator: 'load',
-                    name: `load ${asset.urlOrDescription}`,
-                    at: asset._incoming[0].debugDescription,
                     actual: (asset && asset.urlOrDescription + ': ' || '') + err.message.split('\nIncluding assets:').shift()
-                };
-
-                reportTest(report);
+                });
                 return;
             }
             for (const relation of asset.externalRelations) {
@@ -330,15 +370,22 @@ async function hyperlink({
                 let fragment = relation.fragment;
                 if (fragment) {
                     if (fragment === '#') {
-                        if (relation.to !== asset) {
-                            reportTest({
-                                ok: false,
-                                name: 'Fragment check: ' + relation.from.urlOrDescription + ' --> ' + relation.href,
-                                operator: 'empty-fragment',
-                                expected: 'Fragment identifiers in links to different documents should not be empty',
-                                at: relationDebugDescription(relation)
-                            });
+                        const fragmentReport = {
+                            name: 'fragment-check ' + relation.from.urlOrDescription + ' --> ' + relation.href,
+                            operator: 'fragment-check',
+                            expected: 'Fragment identifiers in links to different documents should not be empty',
+                            at: relationDebugDescription(relation)
+                        };
+
+                        if (!shouldSkip(fragmentReport)) {
+                            if (relation.to !== asset) {
+                                reportTest({
+                                    ...fragmentReport,
+                                    ok: false
+                                });
+                            }
                         }
+
                     } else if (relation.to.type === 'Html') {
                         (relation.to.incomingFragments = relation.to.incomingFragments || []).push({
                             fragment,
@@ -358,24 +405,32 @@ async function hyperlink({
                 }
 
                 // Check for mixed-content warning:
-                if (relation.type === 'HttpRedirect' && relation.from.nonInlineAncestor.protocol === 'https:' && relation.to.protocol === 'http:') {
-                    reportTest({
-                        ok: false,
-                        name: `URI should be secure - ${relation.to.url}`,
-                        operator: 'mixed-content',
-                        expected: `${relation.from.urlOrDescription} --> ${relation.to.url.replace(/\bhttps?:/g, 'https:')}`,
-                        actual: `${relation.from.urlOrDescription} --> ${relation.to.url}`,
-                        at: relationDebugDescription(relation)
-                    });
-                } else if (!['HtmlAnchor', 'SvgAnchor'].includes(relation.type)) {
-                    if (asset.protocol === 'https:' && relation.to.protocol === 'http:') {
+                const mixedContentReport = {
+                    name: `mixed-content ${relation.to.url}`,
+                    operator: 'mixed-content',
+                    at: relationDebugDescription(relation)
+                };
+
+                if (!shouldSkip(mixedContentReport)) {
+                    if (relation.type === 'HttpRedirect' && relation.from.nonInlineAncestor.protocol === 'https:' && relation.to.protocol === 'http:') {
+                        console.log(1)
                         reportTest({
+                            ...mixedContentReport,
                             ok: false,
-                            name: `URI should be secure - ${relation.to.url}`,
-                            operator: 'mixed-content',
+                            expected: `${relation.from.urlOrDescription} --> ${relation.to.url.replace(/\bhttps?:/g, 'https:')}`,
+                            actual: `${relation.from.urlOrDescription} --> ${relation.to.url}`
+                        });
+                    } else if (!['HtmlAnchor', 'SvgAnchor'].includes(relation.type) && asset.protocol === 'https:' && relation.to.protocol === 'http:') {
+                        reportTest({
+                            ...mixedContentReport,
+                            ok: false,
                             expected: relation.to.nonInlineAncestor.url.replace(/\bhttps?:/g, 'https:'),
-                            actual: relation.to.url,
-                            at: relationDebugDescription(relation)
+                            actual: relation.to.url
+                        });
+                    } else {
+                        reportTest({
+                            ...mixedContentReport,
+                            ok: true
                         });
                     }
                 }
@@ -448,26 +503,48 @@ async function hyperlink({
     for (const asset of ag.findAssets()) {
         if (asset.incomingFragments) {
             for (const { fragment, relationDebugDescription, href, fromUrlOrDescription } of asset.incomingFragments) {
-                reportTest({
-                    ok: !!asset.ids && asset.ids.has(fragment.substr(1)),
-                    name: `Fragment check: ${fromUrlOrDescription} --> ${href}`,
-                    operator: 'missing-fragment',
-                    actual: null,
+
+                const fragmentReport = {
+                    operator: 'fragment-check',
+                    name: `fragment-check ${fromUrlOrDescription} --> ${href}`,
                     expected: `id="${fragment.substr(1)}"`,
                     at: relationDebugDescription
-                });
+                };
+
+                if (!shouldSkip(fragmentReport)) {
+                    if (!!asset.ids && asset.ids.has(fragment.substr(1))) {
+                        reportTest({
+                            ...fragmentReport,
+                            ok: true,
+                            actual: fragmentReport.expected
+                        });
+                    } else {
+                        reportTest({
+                            ...fragmentReport,
+                            ok: false,
+                            actual: null
+                        });
+                    }
+                }
+
             }
         }
     }
 
     // Check urls
-    const assetsToCheck = ag.findAssets({check: true});
+    const assetsToCheck = ag.findAssets({check: true})
     t.push({
         name: `Crawling ${assetsToCheck.length} outgoing urls`
     });
 
     await new Promise((resolve, reject) => async.parallelLimit(
-        assetsToCheck.map(asset => httpStatus(asset.url, asset._incoming)),
+        assetsToCheck
+            .filter(asset => !shouldSkip({
+                operator: 'external-check',
+                name: `external-check ${asset.url}`,
+                at: asset._incoming[0].debugDescription
+            }))
+            .map(asset => httpStatus(asset.url, asset._incoming)),
         20,
         err => {
             if (err) {
@@ -487,7 +564,13 @@ async function hyperlink({
     });
 
     await new Promise((resolve, reject) => async.parallelLimit(
-        preconnectAssetsToCheck.map(asset => tryConnect(asset.url, asset._incoming)),
+        preconnectAssetsToCheck
+            .map(asset => tryConnect(asset.url, asset._incoming, {
+                operator: 'preconnect-check',
+                name: `preconnect-check ${asset.url}`,
+                at: [...new Set(asset._incoming.map(r => r.debugDescription))].join('\n        '),
+                expected: `connection accepted ${asset.url}`
+            })),
         20,
         err => {
             if (err) {
@@ -507,7 +590,13 @@ async function hyperlink({
     });
 
     await new Promise((resolve, reject) => async.parallelLimit(
-        dnsPrefetchAssetsToCheck.map(asset => tryConnect(asset.url, asset._incoming)),
+        dnsPrefetchAssetsToCheck
+            .map(asset => tryConnect(asset.url, asset._incoming, {
+                operator: 'dns-prefetch-check',
+                name: `dns-prefetch-check ${asset.hostname}`,
+                at: [...new Set(asset._incoming.map(r => r.debugDescription))].join('\n        '),
+                expected: `DNS exists ${asset.hostname}`
+            })),
         20,
         err => {
             if (err) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,10 +11,6 @@ const tls = require('tls');
 
 const hyperlinkUserAgent = `Hyperlink v${version} (https://www.npmjs.com/package/hyperlink)`
 
-function regexEscape(pattern) {
-    return pattern.replace(/[.+{}[\]()?^$]/g, '\\$&').replace(/\*/g, '.*?');
-}
-
 function returnFalse() { return false; }
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -68,7 +68,14 @@ async function hyperlink({
     ag.teepee.timeout = 30000;
 
     function reportTest(report) {
-        t.push(null, report);
+        const newReport = { ...report };
+        const todo = todoFilter(report);
+
+        if (todo === true || typeof todo === 'string') {
+            newReport.todo = todo;
+        }
+
+        t.push(null, newReport);
     }
 
     function logResult(status, url, redirects = [], incoming = []) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,9 +37,8 @@ function returnFalse() { return false; }
  * @param  {String} options.root AssetGraph instance root
  * @param  {String} [options.canonicalRoot] AssetGraph instance canonicalRoot
  * @param  {String[]} [options.inputUrls = ['index.html']] Files to start the population with
- * @param  {String[]} [options.excludePatterns = []] Url pattern to exclude from population
- * @param  {Function} [options.skipFilter] Filter function to mark failed tests as [skipped](https://testanything.org/tap-version-13-specification.html#skipping-tests)
- * @param  {Function} [options.todoFilter] Filter function to mark failed tests as [todo](https://testanything.org/tap-version-13-specification.html#todo-tests)'s
+ * @param  {Function} [options.skipFilter] Filter function to mark failed tests as [skipped](https://testanything.org/tap-version-13-specification.html#skipping-tests). Return a `String` to add a message or `true` to just mark as skipped
+ * @param  {Function} [options.todoFilter] Filter function to mark failed tests as [todo](https://testanything.org/tap-version-13-specification.html#todo-tests)'s. Return a `String` to add a message or `true` to just mark as todo
  * @param  {Boolean} [options.recursive = false] Recurse onto other pages within the root parameters origin
  * @param  {Boolean} [options.followSourceMaps = false] Check source maps
  * @param  {Boolean} [options.verbose = false] Verbose output from AssetGraph
@@ -52,7 +51,6 @@ async function hyperlink({
     root,
     canonicalRoot,
     inputUrls,
-    excludePatterns = [],
     skipFilter = returnFalse,
     todoFilter = returnFalse,
     recursive = false,
@@ -69,35 +67,16 @@ async function hyperlink({
     ag.teepee.headers['User-Agent'] = hyperlinkUserAgent;
     ag.teepee.timeout = 30000;
 
-    let excludePattern;
-
-    if (excludePatterns.length > 0) {
-        excludePattern = new RegExp(`^(:?${excludePatterns.map(regexEscape).join('|')})`);
-    }
-
-    function shouldSkip(url) {
-        if (excludePattern) {
-            return excludePattern.test(url);
-        }
-
-        return false;
-    }
-
     function reportTest(report) {
         t.push(null, report);
     }
 
-    function logResult(status, url, redirects, incoming) {
-        redirects = redirects || [];
-        incoming = incoming || [];
-
+    function logResult(status, url, redirects = [], incoming = []) {
         const at = _.uniq(incoming.map(r => r.debugDescription)).join('\n        ');
-        const skip = shouldSkip(url);
 
         if (status === false) {
             reportTest({
                 ok: false,
-                skip,
                 name: 'should accept connections',
                 operator: 'error',
                 expected: `connection accepted ${url}`,
@@ -107,7 +86,6 @@ async function hyperlink({
         } else if (status !== 200 && status !== true) {
             reportTest({
                 ok: false,
-                skip,
                 name: 'should respond with HTTP status 200',
                 operator: 'error',
                 expected: `200 ${url}`,
@@ -119,7 +97,6 @@ async function hyperlink({
         if (typeof status !== 'boolean') {
             const report = {
                 ok: true,
-                skip,
                 name: `URI should have no redirects - ${url}`,
                 operator: 'noRedirects',
                 expected: `200 ${url}`,
@@ -272,8 +249,7 @@ async function hyperlink({
             ok: false,
             name: `Failed loading ${error.relation ? 'relation' : (asset && asset.urlOrDescription || 'asset')}`,
             operator: 'error',
-            actual: (asset && asset.urlOrDescription + ': ' || '') + message.split('\nIncluding assets:').shift(),
-            skip: shouldSkip(asset.url)
+            actual: (asset && asset.urlOrDescription + ': ' || '') + message.split('\nIncluding assets:').shift()
         };
 
         if (error.asset) {
@@ -357,8 +333,7 @@ async function hyperlink({
                                 name: 'Fragment check: ' + relation.from.urlOrDescription + ' --> ' + relation.href,
                                 operator: 'empty-fragment',
                                 expected: 'Fragment identifiers in links to different documents should not be empty',
-                                at: relationDebugDescription(relation),
-                                skip: shouldSkip(relation.to.url)
+                                at: relationDebugDescription(relation)
                             });
                         }
                     } else if (relation.to.type === 'Html') {
@@ -383,7 +358,6 @@ async function hyperlink({
                 if (relation.type === 'HttpRedirect' && relation.from.nonInlineAncestor.protocol === 'https:' && relation.to.protocol === 'http:') {
                     reportTest({
                         ok: false,
-                        skip: shouldSkip(relation.to.url),
                         name: `URI should be secure - ${relation.to.url}`,
                         operator: 'mixed-content',
                         expected: `${relation.from.urlOrDescription} --> ${relation.to.url.replace(/\bhttps?:/g, 'https:')}`,
@@ -394,7 +368,6 @@ async function hyperlink({
                     if (asset.protocol === 'https:' && relation.to.protocol === 'http:') {
                         reportTest({
                             ok: false,
-                            skip: shouldSkip(relation.to.url),
                             name: `URI should be secure - ${relation.to.url}`,
                             operator: 'mixed-content',
                             expected: relation.to.nonInlineAncestor.url.replace(/\bhttps?:/g, 'https:'),
@@ -478,8 +451,7 @@ async function hyperlink({
                     operator: 'missing-fragment',
                     actual: null,
                     expected: `id="${fragment.substr(1)}"`,
-                    at: relationDebugDescription,
-                    skip: shouldSkip(asset.url)
+                    at: relationDebugDescription
                 });
             }
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,15 +15,50 @@ function regexEscape(pattern) {
     return pattern.replace(/[.+{}[\]()?^$]/g, '\\$&').replace(/\*/g, '.*?');
 }
 
-module.exports = async function ({
+function returnFalse() { return false; }
+
+/**
+ * A tap-render instance (https://www.npmjs.com/package/tap-render)
+ *
+ * @typedef {Object} TapRender
+ * @property {function} pipe
+ * @property {function} begin
+ * @property {function} push
+ * @property {function} close
+ * @property {function} handleResult
+ *
+ * @return {stream} pause-stream instance (https://www.npmjs.com/package/pause-stream)
+ */
+
+/**
+ * Hyperlink
+ *
+ * @param  {Object} options Hyperlink options
+ * @param  {String} options.root AssetGraph instance root
+ * @param  {String} [options.canonicalRoot] AssetGraph instance canonicalRoot
+ * @param  {String[]} [options.inputUrls = ['index.html']] Files to start the population with
+ * @param  {String[]} [options.excludePatterns = []] Url pattern to exclude from population
+ * @param  {Function} [options.skipFilter] Filter function to mark failed tests as [skipped](https://testanything.org/tap-version-13-specification.html#skipping-tests)
+ * @param  {Function} [options.todoFilter] Filter function to mark failed tests as [todo](https://testanything.org/tap-version-13-specification.html#todo-tests)'s
+ * @param  {Boolean} [options.recursive = false] Recurse onto other pages within the root parameters origin
+ * @param  {Boolean} [options.followSourceMaps = false] Check source maps
+ * @param  {Boolean} [options.verbose = false] Verbose output from AssetGraph
+ * @param  {Boolean} [options.memdebug = false] Memory debugging
+ * @param  {Number} [options.concurrency = 25] Concurrency limit
+ * @param  {TapRender} t tap-render instance
+ * @return {AssetGraph}
+ */
+async function hyperlink({
     root,
     canonicalRoot,
-    excludePatterns,
-    recursive,
-    followSourceMaps,
-    verbose,
     inputUrls,
-    memdebug,
+    excludePatterns = [],
+    skipFilter = returnFalse,
+    todoFilter = returnFalse,
+    recursive = false,
+    followSourceMaps = false,
+    verbose = false,
+    memdebug = false,
     concurrency = 25
 } = {}, t) {
     const ag = new AssetGraph({
@@ -36,7 +71,7 @@ module.exports = async function ({
 
     let excludePattern;
 
-    if (Array.isArray(excludePatterns)) {
+    if (excludePatterns.length > 0) {
         excludePattern = new RegExp(`^(:?${excludePatterns.map(regexEscape).join('|')})`);
     }
 
@@ -48,6 +83,10 @@ module.exports = async function ({
         return false;
     }
 
+    function reportTest(report) {
+        t.push(null, report);
+    }
+
     function logResult(status, url, redirects, incoming) {
         redirects = redirects || [];
         incoming = incoming || [];
@@ -56,7 +95,7 @@ module.exports = async function ({
         const skip = shouldSkip(url);
 
         if (status === false) {
-            t.push(null, {
+            reportTest({
                 ok: false,
                 skip,
                 name: 'should accept connections',
@@ -66,7 +105,7 @@ module.exports = async function ({
                 at
             });
         } else if (status !== 200 && status !== true) {
-            t.push(null, {
+            reportTest({
                 ok: false,
                 skip,
                 name: 'should respond with HTTP status 200',
@@ -111,7 +150,7 @@ module.exports = async function ({
                 report.actual = `${status} ${url}`;
             }
 
-            t.push(null, report);
+            reportTest(report);
         }
     }
 
@@ -249,7 +288,7 @@ module.exports = async function ({
             report.actual.stack += error.stack;
         }
 
-        t.push(null, report);
+        reportTest(report);
     }
 
     ag.on('warn', handleError);
@@ -289,7 +328,7 @@ module.exports = async function ({
             try {
                 await asset.load();
 
-                t.push(null, {
+                reportTest({
                     ok: true,
                     name: `loading ${asset.urlOrDescription}`
                 });
@@ -304,7 +343,7 @@ module.exports = async function ({
                 if (fragment) {
                     if (fragment === '#') {
                         if (relation.to !== asset) {
-                            t.push(null, {
+                            reportTest({
                                 ok: false,
                                 name: 'Fragment check: ' + relation.from.urlOrDescription + ' --> ' + relation.href,
                                 operator: 'empty-fragment',
@@ -333,7 +372,7 @@ module.exports = async function ({
 
                 // Check for mixed-content warning:
                 if (relation.type === 'HttpRedirect' && relation.from.nonInlineAncestor.protocol === 'https:' && relation.to.protocol === 'http:') {
-                    t.push(null, {
+                    reportTest({
                         ok: false,
                         skip: shouldSkip(relation.to.url),
                         name: `URI should be secure - ${relation.to.url}`,
@@ -344,7 +383,7 @@ module.exports = async function ({
                     });
                 } else if (!['HtmlAnchor', 'SvgAnchor'].includes(relation.type)) {
                     if (asset.protocol === 'https:' && relation.to.protocol === 'http:') {
-                        t.push(null, {
+                        reportTest({
                             ok: false,
                             skip: shouldSkip(relation.to.url),
                             name: `URI should be secure - ${relation.to.url}`,
@@ -394,7 +433,7 @@ module.exports = async function ({
 
             // Conserve memory by immediately unloading the asset:
             if (verbose) {
-                t.push(null, {
+                reportTest({
                     ok: true,
                     name: `unloading ${asset.urlOrDescription}`
                 });
@@ -424,7 +463,7 @@ module.exports = async function ({
     for (const asset of ag.findAssets()) {
         if (asset.incomingFragments) {
             for (const { fragment, relationDebugDescription, href, fromUrlOrDescription } of asset.incomingFragments) {
-                t.push(null, {
+                reportTest({
                     ok: !!asset.ids && asset.ids.has(fragment.substr(1)),
                     name: `Fragment check: ${fromUrlOrDescription} --> ${href}`,
                     operator: 'missing-fragment',
@@ -497,3 +536,5 @@ module.exports = async function ({
 
     return ag;
 };
+
+ module.exports = hyperlink;

--- a/lib/index.js
+++ b/lib/index.js
@@ -417,7 +417,6 @@ async function hyperlink({
 
                 if (!shouldSkip(mixedContentReport)) {
                     if (relation.type === 'HttpRedirect' && relation.from.nonInlineAncestor.protocol === 'https:' && relation.to.protocol === 'http:') {
-                        console.log(1)
                         reportTest({
                             ...mixedContentReport,
                             ok: false,

--- a/lib/index.js
+++ b/lib/index.js
@@ -387,7 +387,7 @@ async function hyperlink({
                 } else if (['HtmlAnchor', 'SvgAnchor', 'HtmlIFrame'].includes(relation.type)) {
                     if (!relation.crossorigin && recursive) {
                         follow = true;
-                    } else {
+                    } else if (relation.from !== relation.to) {
                         relation.to.check = true;
                     }
                 } else if (['SourceMapFile', 'SourceMapSource'].includes(relation.type)) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -330,10 +330,19 @@ async function hyperlink({
 
                 reportTest({
                     ok: true,
-                    name: `loading ${asset.urlOrDescription}`
+                    operator: 'load',
+                    name: `load ${asset.urlOrDescription}`
                 });
             } catch (err) {
-                handleError(err);
+                const report = {
+                    ok: false,
+                    operator: 'load',
+                    name: `load ${asset.urlOrDescription}`,
+                    at: asset._incoming[0].debugDescription,
+                    actual: (asset && asset.urlOrDescription + ': ' || '') + err.message.split('\nIncluding assets:').shift()
+                };
+
+                reportTest(report);
                 return;
             }
             for (const relation of asset.externalRelations) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -75,7 +75,8 @@ async function hyperlink({
         if (skip === true || typeof skip === 'string') {
             t.push(null, {
                 ...report,
-                skip
+                skip,
+                ok: true
             });
 
             return true;
@@ -85,15 +86,18 @@ async function hyperlink({
     }
 
     function reportTest(report) {
-        const newReport = { ...report };
+        if (report.ok) {
+            t.push(null, report);
+            return
+        }
 
         const todo = todoFilter(report);
 
         if (todo === true || typeof todo === 'string') {
-            newReport.todo = todo;
+            report.todo = todo;
         }
 
-        t.push(null, newReport);
+        t.push(null, report);
     }
 
     function logResult(status, url, redirects = [], incoming = []) {
@@ -542,7 +546,7 @@ async function hyperlink({
             .filter(asset => !shouldSkip({
                 operator: 'external-check',
                 name: `external-check ${asset.url}`,
-                at: asset._incoming[0].debugDescription
+                at: [...new Set(asset._incoming.map(r => r.debugDescription))].join('\n        ')
             }))
             .map(asset => httpStatus(asset.url, asset._incoming)),
         20,

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "optimist": "^0.6.1",
     "pretty-bytes": "^4.0.2",
     "request": "^2.83.0",
-    "tap-render": "Munter/tap-render#0.1.7-patch2",
+    "tap-render": "Munter/tap-render#0.1.7-patch3",
     "urltools": "^0.3.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "optimist": "^0.6.1",
     "pretty-bytes": "^4.0.2",
     "request": "^2.83.0",
-    "tap-render": "Munter/tap-render#0.1.7-patch1",
+    "tap-render": "Munter/tap-render#0.1.7-patch2",
     "urltools": "^0.3.1"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -102,13 +102,13 @@ describe('hyperlink', function () {
 
             t.push(null, {
                 ok: true,
-                name: `loading index.html`
+                name: `load index.html`
             });
 
             t.push(null, {
                 ok: false,
-                operator: 'error',
-                name: `Failed loading broken.html`,
+                operator: 'load',
+                name: `load broken.html`,
                 actual: expect.it('to begin with', 'broken.html: ENOENT: no such file or directory')
             });
 
@@ -333,8 +333,8 @@ describe('hyperlink', function () {
                 expect(t.push, 'to have a call satisfying', () => {
                     t.push(null, {
                         ok: false,
-                        operator: 'error',
-                        name: 'Failed loading https://example.com/other.css',
+                        operator: 'load',
+                        name: 'load https://example.com/other.css',
                         actual: 'https://example.com/other.css: HTTP 404 Not Found',
                         at: 'https://example.com/styles.css (1:10) '
                     });
@@ -374,8 +374,8 @@ describe('hyperlink', function () {
                 expect(t.push, 'to have a call satisfying', () => {
                     t.push(null, {
                         ok: false,
-                        operator: 'error',
-                        name: 'Failed loading https://somewhereelse.com/other.css',
+                        operator: 'load',
+                        name: 'load https://somewhereelse.com/other.css',
                         actual: 'https://somewhereelse.com/other.css: HTTP 404 Not Found',
                         at: 'https://example.com/styles.css (1:10) '
                     });
@@ -729,7 +729,7 @@ describe('hyperlink', function () {
             expect(t.push, 'to have a call satisfying', () => {
                 t.push(null, {
                     skip: true,
-                    name: 'Failed loading https://example.com/script.js'
+                    name: 'load https://example.com/script.js'
                 });
             });
         });

--- a/test/index.js
+++ b/test/index.js
@@ -697,41 +697,4 @@ describe('hyperlink', function () {
         });
     });
 
-    describe('with excludePatterns', function () {
-        it('should report problems, but mark the entry as skipped', async function () {
-            httpception([
-                {
-                    request: 'GET https://example.com/',
-                    response: {
-                        statusCode: 200,
-                        headers: {
-                            'Content-Type': 'text/html; charset=UTF-8'
-                        },
-                        body: '<html><head><script src="script.js"></script></head><body></body></html>'
-                    }
-                },
-                {
-                    request: 'GET https://example.com/script.js',
-                    response: 404
-                }
-            ]);
-
-            const t = new TapRender();
-            sinon.spy(t, 'push');
-            await hyperlink({
-                recursive: false,
-                root: 'https://example.com/',
-                inputUrls: [ 'https://example.com/' ],
-                excludePatterns: [ 'https://example.com/script.js' ]
-            }, t);
-
-            expect(t.close(), 'to satisfy', {fail: 0, skip: 1});
-            expect(t.push, 'to have a call satisfying', () => {
-                t.push(null, {
-                    skip: true,
-                    name: 'load https://example.com/script.js'
-                });
-            });
-        });
-    });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -784,7 +784,7 @@ describe('hyperlink', function () {
             expect(t.close(), 'to satisfy', {fail: 0, skip: 1});
             expect(t.push, 'to have a call satisfying', () => {
                 t.push(null, {
-                    ok: undefined,
+                    ok: true,
                     skip: true,
                     operator: 'load',
                     name: 'load https://example.com/script.js'
@@ -822,7 +822,7 @@ describe('hyperlink', function () {
             expect(t.close(), 'to satisfy', {fail: 0, skip: 1});
             expect(t.push, 'to have a call satisfying', () => {
                 t.push(null, {
-                    ok: undefined,
+                    ok: true,
                     skip: 'Skip this one',
                     operator: 'load',
                     name: 'load https://example.com/script.js'

--- a/test/index.js
+++ b/test/index.js
@@ -115,7 +115,7 @@ describe('hyperlink', function () {
             t.push(null, {
                 ok: true,
                 operator: 'mixed-content',
-                name: `mixed-content file:///Users/munter/git/hyperlink/broken.html`,
+                name: `mixed-content ${root}/broken.html`,
                 at: 'index.html:1:37 <a href="broken.html">...</a>'
             });
 


### PR DESCRIPTION
The `skipFilter` option lets a programmatic user match against properties of a tap-report before the test is run and skip the test by returning `true`.

The `todoFilter` option lets a programmatic user match against properties of a tap-report after a test has failed and mark the test at `todo` by returning `true`.

Added `--skip` CLI option that takes strings and does naive string matching against a tap reports values and returns true for any match. This is sent into `skipFilter`

Added `--todo` CLI option that takes strings and does naive string matching against a tap reports values and returns true for any match. This is sent into `todoFilter`

Deprecated `--exclude` CLI option