### PR TITLE
Fix the behavior of followSourceMaps:true

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -366,10 +366,14 @@ module.exports = async function ({
                     } else {
                         relation.to.check = true;
                     }
-                } else if (['SourceMapFile', 'SourceMapSource'].includes(relation.type)) {
+                } else if (/^(?:JavaScript|Css)Source(?:Mapping)Url$/.test(relation.type)) {
                     if (followSourceMaps) {
                         follow = true;
                     } else {
+                        relation.to.check = true;
+                    }
+                } else if (['SourceMapFile', 'SourceMapSource'].includes(relation.type)) {
+                    if (followSourceMaps) {
                         relation.to.check = true;
                     }
                 } else {


### PR DESCRIPTION
- `//# sourceMappingURL=...` references will always be checked with with a `HEAD` request
- If followSourceMaps is true, also load the source map and `HEAD` the urls of the sources and generated file as well