### PR TITLE
Check Content-Type headers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -311,7 +311,6 @@ async function hyperlink({
     function handleError(error) {
         const message = error.message || error;
         const asset = error.asset || (error.relation && error.relation.to);
-
         const report = {
             ok: false,
             name: `Failed loading ${error.relation ? 'relation' : (asset && asset.urlOrDescription || 'asset')}`,

--- a/lib/index.js
+++ b/lib/index.js
@@ -274,7 +274,7 @@ async function hyperlink({
                                     reportTest({
                                         ok: false,
                                         skip,
-                                        name: 'Should have the expected Content-Type',
+                                        name: `${asset.urlOrDescription}: Should have the expected Content-Type`,
                                         operator: 'error',
                                         expected,
                                         actual: contentType,
@@ -282,8 +282,19 @@ async function hyperlink({
                                     });
                                 }
                             }
-                        } else {
-                            // Complain
+                        } else if (!contentType) {
+                            const at = _.uniq(relations.map(r => r.debugDescription)).join('\n        ');
+                            const skip = shouldSkip(asset.url);
+
+                            reportTest({
+                                ok: false,
+                                skip,
+                                name: `${asset.urlOrDescription}: No Content-Type response header`,
+                                operator: 'error',
+                                expected: asset.contentType || `A Content-Type compatible with ${asset.type}`,
+                                actual: contentType,
+                                at
+                            });
                         }
                     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -192,6 +192,7 @@ async function hyperlink({
                 }
 
                 const status = res.statusCode;
+
                 if (status >= 200 && status < 300) {
                     const contentType = res.headers['content-type'];
                     if (contentType && asset.type) {
@@ -202,32 +203,35 @@ async function hyperlink({
                             const expected = asset.contentType || `A Content-Type compatible with ${asset.type}`;
                             asset.contentType = matchContentType[1].toLowerCase();
                             const inferredType = asset._inferType();
-                            if (!asset._isCompatibleWith(inferredType)) {
-                                const skip = shouldSkip(asset.url);
 
+                            const contentTypeMismatchReport = {
+                                operator: 'content-type-mismatch',
+                                name: `content-type-mismatch ${asset.urlOrDescription}`,
+                                expected,
+                                actual: contentType,
+                                at: [...new Set(relations.map(r => r.debugDescription))].join('\n        '),
+                            };
+
+                            if (!shouldSkip(contentTypeMismatchReport)) {
                                 reportTest({
-                                    ok: false,
-                                    skip,
-                                    name: `${asset.urlOrDescription}: Should have the expected Content-Type`,
-                                    operator: 'error',
-                                    expected,
-                                    actual: contentType,
-                                    at: [...new Set(relations.map(r => r.debugDescription))].join('\n        '),
+                                    ...contentTypeMismatchReport,
+                                    ok: asset._isCompatibleWith(inferredType)
                                 });
                             }
                         }
                     } else if (!contentType) {
-                        const skip = shouldSkip(asset.url);
-
-                        reportTest({
+                        const contentTypeMisingReport = {
                             ok: false,
-                            skip,
-                            name: `${asset.urlOrDescription}: No Content-Type response header`,
-                            operator: 'error',
+                            name: `content-type-missing ${asset.urlOrDescription}`,
+                            operator: 'content-type-missing',
                             expected: asset.contentType || `A Content-Type compatible with ${asset.type}`,
                             actual: contentType,
                             at: [...new Set(relations.map(r => r.debugDescription))].join('\n        '),
-                        });
+                        };
+
+                        if (!shouldSkip(contentTypeMisingReport)) {
+                            reportTest(contentTypeMisingReport);
+                        };
                     }
                 }
 
@@ -327,6 +331,27 @@ async function hyperlink({
     }
 
     function handleError(error) {
+        // Explicitly handle incompatible types warning
+        if (error.stack && error.stack.includes('_warnIncompatibleTypes')) {
+            const asset = error.asset;
+            const expected = asset.contentType || `A Content-Type compatible with ${asset.type}`;
+
+            const contentTypeMismatchReport = {
+                ok: false,
+                operator: 'content-type-mismatch',
+                name: `content-type-mismatch ${asset.urlOrDescription}`,
+                expected,
+                actual: error.message,
+                at: [...new Set(asset._incoming.map(r => r.debugDescription))].join('\n        '),
+            };
+
+            if (!shouldSkip(contentTypeMismatchReport)) {
+                reportTest(contentTypeMismatchReport)
+            }
+
+            return;
+        }
+
         const message = error.message || error;
         const asset = error.asset || (error.relation && error.relation.to);
         const report = {

--- a/lib/index.js
+++ b/lib/index.js
@@ -205,11 +205,11 @@ async function hyperlink({
         };
     }
 
-    function httpStatus(url, relations, attempt = 1) {
+    function httpStatus(asset, relations, attempt = 1) {
         return callback => {
             request({
                 method: attempt === 1 ? 'head' : 'get',
-                url: url.replace(/#.*$/, ''),
+                url: asset.url,
                 strictSSL: true,
                 gzip: true,
                 headers: {
@@ -226,7 +226,7 @@ async function hyperlink({
                     if (code) {
                         // Some servers send responses that request apparently handles badly when using the HEAD method...
                         if (code === 'HPE_INVALID_CONSTANT' && attempt === 1) {
-                            return httpStatus(url, relations, attempt + 1)(callback);
+                            return httpStatus(asset, relations, attempt + 1)(callback);
                         }
 
                         if (code === 'ENOTFOUND') {
@@ -238,29 +238,59 @@ async function hyperlink({
                         status = 'Unknown error';
                     }
 
-                    logResult(status, url, undefined, relations);
+                    logResult(status, asset.url, undefined, relations);
 
                     callback(undefined, status);
                 } else {
                     // Some servers respond weirdly to HEAD requests. Make a second attempt with GET
                     if (attempt === 1 && res.statusCode >= 400 && res.statusCode < 600) {
-                        return httpStatus(url, relations, attempt + 1)(callback);
+                        return httpStatus(asset, relations, attempt + 1)(callback);
                     }
 
                     // Some servers (jspm.io) respond with 502 if requesting HEAD, then GET to close in succession. Give the server a second to cool down
                     if (attempt === 2 && res.statusCode === 502) {
                         setTimeout(
-                            () => httpStatus(url, relations, attempt + 1)(callback),
+                            () => httpStatus(asset, relations, attempt + 1)(callback),
                             1000
                         );
                         return;
                     }
 
                     status = res.statusCode;
+                    if (status >= 200 && status < 300) {
+                        const contentType = res.headers['content-type'];
+                        if (contentType && asset.type) {
+                            const matchContentType = contentType.match(
+                                /^\s*([\w\-+.]+\/[\w-+.]+)(?:\s|;|$)/i
+                            );
+                            if (matchContentType) {
+                                const expected = asset.contentType || `A Content-Type compatible with ${asset.type}`;
+                                asset.contentType = matchContentType[1].toLowerCase();
+                                const inferredType = asset._inferType();
+                                if (!asset._isCompatibleWith(inferredType)) {
+                                    const at = _.uniq(relations.map(r => r.debugDescription)).join('\n        ');
+                                    const skip = shouldSkip(asset.url);
+
+                                    reportTest({
+                                        ok: false,
+                                        skip,
+                                        name: 'Should have the expected Content-Type',
+                                        operator: 'error',
+                                        expected,
+                                        actual: contentType,
+                                        at
+                                    });
+                                }
+                            }
+                        } else {
+                            // Complain
+                        }
+                    }
+
                     const redirects = res.request._redirect.redirects || [];
                     const firstRedirectStatus = redirects[0] && redirects[0].statusCode;
 
-                    logResult(status, url, redirects, relations);
+                    logResult(status, asset.url, redirects, relations);
 
                     callback(undefined, firstRedirectStatus || status);
                 }
@@ -547,7 +577,7 @@ async function hyperlink({
                 name: `external-check ${asset.url}`,
                 at: [...new Set(asset._incoming.map(r => r.debugDescription))].join('\n        ')
             }))
-            .map(asset => httpStatus(asset.url, asset._incoming)),
+            .map(asset => httpStatus(asset, asset._incoming)),
         20,
         err => {
             if (err) {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   ],
   "homepage": "https://github.com/Munter/hyperlink",
   "dependencies": {
-    "assetgraph": "^4.3.0",
+    "assetgraph": "^4.3.1",
     "async": "^2.6.0",
     "lodash": "^4.17.4",
     "optimist": "^0.6.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   ],
   "homepage": "https://github.com/Munter/hyperlink",
   "dependencies": {
-    "assetgraph": "^4.1.1",
+    "assetgraph": "^4.3.0",
     "async": "^2.6.0",
     "lodash": "^4.17.4",
     "optimist": "^0.6.1",

--- a/test/index.js
+++ b/test/index.js
@@ -97,8 +97,10 @@ describe('hyperlink', function () {
         expect(t.push, 'to have a call satisfying', () => {
             t.push(null, {
                 ok: false,
-                operator: 'error',
-                actual: 'https://example.com/styles.css: Asset is used as both Css and Png',
+                operator: 'content-type-mismatch',
+                name: 'content-type-mismatch https://example.com/styles.css',
+                expected: 'text/css',
+                actual: 'Asset is used as both Css and Png',
                 at: 'https://example.com/ (5:58) <link rel="stylesheet" href="styles.css">'
             });
         });
@@ -145,8 +147,8 @@ describe('hyperlink', function () {
         expect(t.push, 'to have a call satisfying', () => {
             t.push(null, {
                 ok: false,
-                operator: 'error',
-                name: 'https://example.com/hey.png: Should have the expected Content-Type',
+                operator: 'content-type-mismatch',
+                name: 'content-type-mismatch https://example.com/hey.png',
                 expected: 'image/png',
                 actual: 'text/plain',
                 at: 'https://example.com/ (6:39) <img src="hey.png">'
@@ -191,8 +193,8 @@ describe('hyperlink', function () {
         expect(t.push, 'to have a call satisfying', () => {
             t.push(null, {
                 ok: false,
-                operator: 'error',
-                name: 'https://example.com/hey.png: No Content-Type response header',
+                operator: 'content-type-missing',
+                name: 'content-type-missing https://example.com/hey.png',
                 expected: 'image/png',
                 at: 'https://example.com/ (6:39) <img src="hey.png">'
             });


### PR DESCRIPTION
Complain if a `HEAD` request returns a `Content-Type` that contradicts what we expected based on the incoming relations, or if it is missing.

Also, test that we emit warnings during the regular population when a similar situation occurs.