### PR TITLE
Fix problem with failing fragment check on non-loaded external html assets

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,9 +7,7 @@ const prettyBytes = require('pretty-bytes');
 const net = require('net');
 const tls = require('tls');
 
-const defaultSkipFilters = [
-  require('./known-culprits/linkedin')
-];
+const defaultSkipFilters = [require('./known-culprits/linkedin')];
 
 const hyperlinkUserAgent = `Hyperlink v${version} (https://www.npmjs.com/package/hyperlink)`;
 
@@ -470,6 +468,16 @@ async function hyperlink(
         return;
       }
 
+      if (asset.type === 'Html') {
+        // Remember the set of ids in the document before unloading so incoming fragments can be checked:
+        asset.ids = new Set();
+        for (const element of Array.from(
+          asset.parseTree.querySelectorAll('[id]')
+        )) {
+          asset.ids.add(element.getAttribute('id'));
+        }
+      }
+
       // In non-recursive mode local assets might be marked as end-of-line.
       // This is specifically relevant to local file-URLs
       if (asset.stopProcessing) {
@@ -581,6 +589,9 @@ async function hyperlink(
             ) {
               follow = true;
               relation.to.stopProcessing = true;
+            } else if (relation.fragment && relation.fragment !== '#') {
+              follow = true;
+              relation.to.stopProcessing = true;
             } else {
               relation.to.check = true;
             }
@@ -618,16 +629,6 @@ async function hyperlink(
           } else {
             assetQueue.push(relation.to);
           }
-        }
-      }
-
-      if (asset.type === 'Html') {
-        // Remember the set of ids in the document before unloading so incoming fragments can be checked:
-        asset.ids = new Set();
-        for (const element of Array.from(
-          asset.parseTree.querySelectorAll('[id]')
-        )) {
-          asset.ids.add(element.getAttribute('id'));
         }
       }
 

--- a/test/index.js
+++ b/test/index.js
@@ -622,6 +622,55 @@ describe('hyperlink', function() {
       });
     });
 
+    it('should not issue an error when referencing an external asset with an existing fragment', async function() {
+      httpception([
+        {
+          request: 'GET https://example.com/',
+          response: {
+            statusCode: 200,
+            headers: {
+              'Content-Type': 'text/html; charset=UTF-8'
+            },
+            body:
+              '<html><head></head><body><a href="https://example2.com/foo.html#frag">Link</a></body></html>'
+          }
+        },
+        {
+          request: 'GET https://example2.com/foo.html',
+          response: {
+            statusCode: 200,
+            headers: {
+              'Content-Type': 'text/html; charset=UTF-8'
+            },
+            body:
+              '<html><head></head><body><main id="frag">I exist</main></body></html>'
+          }
+        }
+      ]);
+
+      const t = new TapRender();
+      sinon.spy(t, 'push');
+      await hyperlink(
+        {
+          recursive: true,
+          root: 'https://example.com/',
+          inputUrls: ['https://example.com/']
+        },
+        t
+      );
+
+      expect(t.close(), 'to satisfy', { fail: 0 });
+      expect(t.push, 'to have a call satisfying', () => {
+        t.push(null, {
+          ok: true,
+          operator: 'fragment-check',
+          name:
+            'fragment-check https://example.com/ --> https://example2.com/foo.html#frag',
+          expected: 'id="frag"'
+        });
+      });
+    });
+
     it('should be fine when an asset references itself with an empty fragment', async function() {
       httpception([
         {


### PR DESCRIPTION
As talked about in gitter, anchors (and similar) to external assets, which contain fragment identifiers, failed the fragment-check test because the external asset was never loaded.

- Mark the external asset for loading if the relation has a fragment
- Collect the assets `id`'s before stopping the further processing