### PR TITLE
Run fragment-check when `internal` flag is true

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -677,39 +677,40 @@ async function hyperlink(
 
   // Check fragments
 
-  for (const asset of ag.findAssets()) {
+  for (const asset of ag.findAssets({
+    type: 'Html',
+    incomingFragments: { $exists: true }
+  })) {
     if (internalOnly && !asset.isLoaded) {
       continue;
     }
 
-    if (asset.incomingFragments && asset.type === 'Html') {
-      for (const {
-        fragment,
-        relationDebugDescription,
-        href,
-        fromUrlOrDescription
-      } of asset.incomingFragments) {
-        const fragmentReport = {
-          operator: 'fragment-check',
-          name: `fragment-check ${fromUrlOrDescription} --> ${href}`,
-          expected: `id="${fragment.substr(1)}"`,
-          at: relationDebugDescription
-        };
+    for (const {
+      fragment,
+      relationDebugDescription,
+      href,
+      fromUrlOrDescription
+    } of asset.incomingFragments) {
+      const fragmentReport = {
+        operator: 'fragment-check',
+        name: `fragment-check ${fromUrlOrDescription} --> ${href}`,
+        expected: `id="${fragment.substr(1)}"`,
+        at: relationDebugDescription
+      };
 
-        if (!shouldSkip(fragmentReport)) {
-          if (asset.ids && asset.ids.has(fragment.substr(1))) {
-            reportTest({
-              ...fragmentReport,
-              ok: true,
-              actual: fragmentReport.expected
-            });
-          } else {
-            reportTest({
-              ...fragmentReport,
-              ok: false,
-              actual: null
-            });
-          }
+      if (!shouldSkip(fragmentReport)) {
+        if (asset.ids && asset.ids.has(fragment.substr(1))) {
+          reportTest({
+            ...fragmentReport,
+            ok: true,
+            actual: fragmentReport.expected
+          });
+        } else {
+          reportTest({
+            ...fragmentReport,
+            ok: false,
+            actual: null
+          });
         }
       }
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -681,10 +681,6 @@ async function hyperlink(
     type: 'Html',
     incomingFragments: { $exists: true }
   })) {
-    if (internalOnly && !asset.isLoaded) {
-      continue;
-    }
-
     for (const {
       fragment,
       relationDebugDescription,

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "prettier": "~1.14.0",
     "sinon": "^4.4.5",
     "unexpected": "^10.36.2",
+    "unexpected-set": "^2.0.0",
     "unexpected-sinon": "^10.8.2"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -2108,5 +2108,103 @@ describe('hyperlink', function() {
 
       expect(t.close(), 'to satisfy', { fail: 0 });
     });
+
+    it('should follow fragment links withing the same page', async () => {
+      const t = new TapRender();
+      // t.pipe(process.stdout);
+      sinon.spy(t, 'push');
+      await hyperlink(
+        {
+          root: pathModule.resolve(
+            __dirname,
+            '..',
+            'testdata',
+            'internalfragment'
+          ),
+          inputUrls: ['singlepage.html'],
+          recursive: true,
+          internalOnly: true
+        },
+        t
+      );
+
+      expect(
+        t.push
+          .withArgs(null)
+          .getCalls()
+          .map(c => c.args[1]),
+        'to satisfy',
+        [
+          {
+            operator: 'load',
+            name: 'load testdata/internalfragment/singlepage.html',
+            ok: true
+          },
+
+          {
+            operator: 'fragment-check',
+            name:
+              'fragment-check testdata/internalfragment/singlepage.html --> #broken',
+            expected: 'id="broken"',
+            at:
+              'testdata/internalfragment/singlepage.html:1:10 <a href="#broken">...</a>',
+            ok: false,
+            actual: null
+          }
+        ]
+      );
+      expect(t.close(), 'to satisfy', { fail: 1 });
+    });
+
+    it('should follow fragment links across pages', async () => {
+      const t = new TapRender();
+      // t.pipe(process.stdout);
+      sinon.spy(t, 'push');
+      await hyperlink(
+        {
+          root: pathModule.resolve(
+            __dirname,
+            '..',
+            'testdata',
+            'internalfragment'
+          ),
+          inputUrls: ['multi-page1.html'],
+          recursive: true,
+          internalOnly: true
+        },
+        t
+      );
+
+      expect(
+        t.push
+          .withArgs(null)
+          .getCalls()
+          .map(c => c.args[1]),
+        'to satisfy',
+        [
+          {
+            operator: 'load',
+            name: 'load testdata/internalfragment/multi-page1.html',
+            ok: true
+          },
+          {
+            operator: 'load',
+            name: 'load testdata/internalfragment/multi-page2.html',
+            ok: true
+          },
+          {
+            operator: 'fragment-check',
+            name:
+              'fragment-check testdata/internalfragment/multi-page2.html --> multi-page2.html#broken',
+            expected: 'id="broken"',
+            at:
+              'testdata/internalfragment/multi-page2.html:1:10 <a href="multi-page2.html#broken">...</a>',
+            ok: false,
+            actual: null
+          }
+        ]
+      );
+      expect(t.close(), 'to satisfy', { fail: 1 });
+    });
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -1,12 +1,20 @@
 /*global describe, it, console:true*/
 const expect = require('unexpected')
   .clone()
+  .use(require('unexpected-set'))
   .use(require('unexpected-sinon'));
 const hyperlink = require('../lib/');
 const httpception = require('httpception');
 const TapRender = require('tap-render');
 const sinon = require('sinon');
 const pathModule = require('path');
+
+function spyTapCalls(spy) {
+  return spy
+    .withArgs(null)
+    .getCalls()
+    .map(c => c.args[1]);
+}
 
 describe('hyperlink', function() {
   it('should complain about insecure content warnings', async function() {
@@ -441,6 +449,60 @@ describe('hyperlink', function() {
         t
       );
 
+      expect(spyTapCalls(t.push), 'with set semantics to satisfy', [
+        {
+          operator: 'load',
+          name: 'load testdata/recursive/index.html',
+          ok: true
+        },
+        {
+          operator: 'load',
+          name: 'load testdata/recursive/style.css',
+          ok: true
+        },
+        {
+          operator: 'load',
+          name: 'load testdata/recursive/favicon.ico',
+          ok: true
+        },
+        {
+          operator: 'load',
+          name: 'load testdata/recursive/page.html',
+          ok: true
+        },
+        {
+          operator: 'load',
+          name: 'load testdata/recursive/hyperlink.gif',
+          ok: true
+        },
+        {
+          operator: 'load',
+          name: 'load testdata/recursive/bf176a25b4f8227fea804854c98dc5e2.png',
+          ok: true
+        },
+        {
+          operator: 'load',
+          name:
+            'load testdata/recursive/1ebd0482aadade65f20ec178219fe012.woff2',
+          ok: true
+        },
+        {
+          operator: 'load',
+          name: 'load testdata/recursive/314bbcd238d458622bbf32427346774f.woff',
+          ok: true
+        },
+        {
+          operator: 'fragment-check',
+          name:
+            'fragment-check testdata/recursive/page.html --> index.html#brokenfragment',
+          expected: 'id="brokenfragment"',
+          at:
+            'testdata/recursive/page.html:8:14 <a href="index.html#brokenfragment">...</a>',
+          ok: false,
+          actual: null
+        }
+      ]);
+
       expect(t.close(), 'to satisfy', {
         count: 9,
         pass: 8,
@@ -448,6 +510,7 @@ describe('hyperlink', function() {
         skip: 0,
         todo: 0
       });
+
       expect(t.push, 'to have a call satisfying', () => {
         t.push({
           name: 'Crawling 0 outgoing urls'
@@ -2128,31 +2191,24 @@ describe('hyperlink', function() {
         t
       );
 
-      expect(
-        t.push
-          .withArgs(null)
-          .getCalls()
-          .map(c => c.args[1]),
-        'to satisfy',
-        [
-          {
-            operator: 'load',
-            name: 'load testdata/internalfragment/singlepage.html',
-            ok: true
-          },
+      expect(spyTapCalls(t.push), 'to satisfy', [
+        {
+          operator: 'load',
+          name: 'load testdata/internalfragment/singlepage.html',
+          ok: true
+        },
 
-          {
-            operator: 'fragment-check',
-            name:
-              'fragment-check testdata/internalfragment/singlepage.html --> #broken',
-            expected: 'id="broken"',
-            at:
-              'testdata/internalfragment/singlepage.html:1:10 <a href="#broken">...</a>',
-            ok: false,
-            actual: null
-          }
-        ]
-      );
+        {
+          operator: 'fragment-check',
+          name:
+            'fragment-check testdata/internalfragment/singlepage.html --> #broken',
+          expected: 'id="broken"',
+          at:
+            'testdata/internalfragment/singlepage.html:1:10 <a href="#broken">...</a>',
+          ok: false,
+          actual: null
+        }
+      ]);
       expect(t.close(), 'to satisfy', { fail: 1 });
     });
 
@@ -2175,35 +2231,28 @@ describe('hyperlink', function() {
         t
       );
 
-      expect(
-        t.push
-          .withArgs(null)
-          .getCalls()
-          .map(c => c.args[1]),
-        'to satisfy',
-        [
-          {
-            operator: 'load',
-            name: 'load testdata/internalfragment/multi-page1.html',
-            ok: true
-          },
-          {
-            operator: 'load',
-            name: 'load testdata/internalfragment/multi-page2.html',
-            ok: true
-          },
-          {
-            operator: 'fragment-check',
-            name:
-              'fragment-check testdata/internalfragment/multi-page2.html --> multi-page2.html#broken',
-            expected: 'id="broken"',
-            at:
-              'testdata/internalfragment/multi-page2.html:1:10 <a href="multi-page2.html#broken">...</a>',
-            ok: false,
-            actual: null
-          }
-        ]
-      );
+      expect(spyTapCalls(t.push), 'to satisfy', [
+        {
+          operator: 'load',
+          name: 'load testdata/internalfragment/multi-page1.html',
+          ok: true
+        },
+        {
+          operator: 'load',
+          name: 'load testdata/internalfragment/multi-page2.html',
+          ok: true
+        },
+        {
+          operator: 'fragment-check',
+          name:
+            'fragment-check testdata/internalfragment/multi-page2.html --> multi-page2.html#broken',
+          expected: 'id="broken"',
+          at:
+            'testdata/internalfragment/multi-page2.html:1:10 <a href="multi-page2.html#broken">...</a>',
+          ok: false,
+          actual: null
+        }
+      ]);
       expect(t.close(), 'to satisfy', { fail: 1 });
     });
   });

--- a/test/index.js
+++ b/test/index.js
@@ -2172,7 +2172,7 @@ describe('hyperlink', function() {
       expect(t.close(), 'to satisfy', { fail: 0 });
     });
 
-    it('should follow fragment links withing the same page', async () => {
+    it('should follow fragment links within the same page', async () => {
       const t = new TapRender();
       // t.pipe(process.stdout);
       sinon.spy(t, 'push');

--- a/testdata/internalfragment/multi-page1.html
+++ b/testdata/internalfragment/multi-page1.html
@@ -1,0 +1,1 @@
+<a href="multi-page2.html">page 2</a>

--- a/testdata/internalfragment/multi-page2.html
+++ b/testdata/internalfragment/multi-page2.html
@@ -1,0 +1,1 @@
+<a href="multi-page2.html#broken">page 1</a>

--- a/testdata/internalfragment/singlepage.html
+++ b/testdata/internalfragment/singlepage.html
@@ -1,0 +1,1 @@
+<a href="#broken">broken</a>


### PR DESCRIPTION
Fixes #152 

When running with the `internal` flag or `--internal` in the CLI, fragment checks were not run at all. Also not for completely site internal fragment links.