### PR TITLE
Output valid TAP details without any stray colons that cause parsers …

### DIFF
--- a/lib/relationDebugDescription.js
+++ b/lib/relationDebugDescription.js
@@ -18,8 +18,8 @@ module.exports = function relationDebugDescription(relation) {
 
     var node = relation.node;
 
-    if (relation.from.isInline) {
-      details += 'inlined ' + relation.from.type + ': ';
+    if (relation.from.isInline && asset.type !== relation.from.type) {
+      details += `(inlined ${relation.from.type}) `;
     }
 
     // DOM node

--- a/test/relationDebugDescription-test.js
+++ b/test/relationDebugDescription-test.js
@@ -106,7 +106,7 @@ describe('relationDebugDescription', function() {
         expect(
           result,
           'to end with',
-          'index.html:1:58 inlined Css: url(https://mntr.dk/invalid.png)'
+          'index.html:1:58 (inlined Css) url(https://mntr.dk/invalid.png)'
         );
       });
   });


### PR DESCRIPTION
…to fail in a details block