### PR TITLE
Feature/handle GitHub readme fragments

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -708,11 +708,24 @@ async function hyperlink(
             actual: fragmentReport.expected
           });
         } else {
-          reportTest({
-            ...fragmentReport,
-            ok: false,
-            actual: null
-          });
+          // Github does some weird things with mangling fragments and reversing it with runtime js
+          if (
+            asset.origin === 'https://github.com' &&
+            asset.ids &&
+            asset.ids.has(`user-content-${fragment.substr(1)}`)
+          ) {
+            reportTest({
+              ...fragmentReport,
+              ok: true,
+              actual: `id="user-content-${fragment.substr(1)}"`
+            });
+          } else {
+            reportTest({
+              ...fragmentReport,
+              ok: false,
+              actual: null
+            });
+          }
         }
       }
     }


### PR DESCRIPTION
Github does a weird rewrite of heading fragments where they have a slugified link to a fragment that represents the user content, but the corresponding id-attribute has a prepended `user-content-`, which they then figure out how to navigate to with javascript.

```html
<a id="user-content-6-test262-status" class="anchor" aria-hidden="true" href="#6-test262-status">
```

This caused problems with hyperlinks fragment check. Hyperlink now re-tries checking the fragment with the prepended string if the content is on github.com