### PR TITLE
Emit an error if a relation with a fragment gets redirected

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -672,6 +672,28 @@ async function hyperlink(
             assetQueue.add(relation.to);
           }
         } else {
+          if (
+            typeof redirectAsset.statusCode === 'number' || // HttpRedirect
+            !/\/(?:\?|$)/.test(redirectAsset.url)
+          ) {
+            for (const {
+              fragment,
+              relationDebugDescription,
+              fromUrlOrDescription
+            } of redirectAsset.incomingFragments) {
+              const fragmentRedirectReport = {
+                operator: 'fragment-redirect',
+                name: `fragment-redirect ${fromUrlOrDescription} --> ${redirectAsset.urlOrDescription}${fragment} --> ${redirectAsset.outgoingRelations[0].to.urlOrDescription}`,
+                at: relationDebugDescription
+              };
+              if (!shouldSkip(fragmentRedirectReport)) {
+                reportTest({
+                  ...fragmentRedirectReport,
+                  ok: false
+                });
+              }
+            }
+          }
           (asset.incomingFragments = asset.incomingFragments || []).push(
             ...redirectAsset.incomingFragments
           );

--- a/test/index.js
+++ b/test/index.js
@@ -613,6 +613,171 @@ describe('hyperlink', function() {
       });
     });
 
+    describe('with an implicit index.html in a subdir via FileRedirect', function() {
+      it('should complain about a fragment when there is no trailing slash on the href, even though the fragment exists', async function() {
+        const t = new TapRender();
+        sinon.spy(t, 'push');
+        await hyperlink(
+          {
+            recursive: false,
+            root: pathModule.resolve(
+              __dirname,
+              '..',
+              'testdata',
+              'fragmentAndRedirectWithoutSlash'
+            ),
+            inputUrls: ['index.html']
+          },
+          t
+        );
+
+        expect(t.push, 'to have a call satisfying', () => {
+          t.push(null, {
+            operator: 'fragment-redirect',
+            name:
+              'fragment-redirect testdata/fragmentAndRedirectWithoutSlash/index.html --> testdata/fragmentAndRedirectWithoutSlash/subdir#myFragment --> testdata/fragmentAndRedirectWithoutSlash/subdir/index.html',
+            at:
+              'testdata/fragmentAndRedirectWithoutSlash/index.html:5:12 <a href="/subdir#myFragment">...</a>',
+            ok: false
+          });
+        });
+      });
+
+      it('should not complain about a fragment when there is a trailing slash on the href', async function() {
+        const t = new TapRender();
+        sinon.spy(t, 'push');
+        await hyperlink(
+          {
+            recursive: false,
+            root: pathModule.resolve(
+              __dirname,
+              '..',
+              'testdata',
+              'fragmentAndRedirectWithSlash'
+            ),
+            inputUrls: ['index.html']
+          },
+          t
+        );
+
+        expect(t.push, 'to have no calls satisfying', () => {
+          t.push(null, {
+            operator: 'fragment-redirect'
+          });
+        });
+      });
+    });
+
+    describe('with an implicit index.html in a subdir via HttpRedirect', function() {
+      it('should complain about a fragment href pointing to a page that is redirected, even though the fragment exists', async function() {
+        httpception([
+          {
+            request: 'GET https://example.com/',
+            response: {
+              headers: {
+                'Content-Type': 'text/html'
+              },
+              body: `<!DOCTYPE html><html><head></head><body><a href="/subdir#myFragment"></a></body></html>`
+            }
+          },
+          {
+            request: 'GET https://example.com/subdir',
+            response: {
+              statusCode: 302,
+              headers: {
+                Location: 'https://example.com/subdir/'
+              }
+            }
+          },
+          {
+            request: 'GET https://example.com/subdir/',
+            response: {
+              headers: {
+                'Content-Type': 'text/html'
+              },
+              body: `<!DOCTYPE html><html><head></head><body><div id="myFragment"></div></body></html>`
+            }
+          }
+        ]);
+
+        const t = new TapRender();
+        sinon.spy(t, 'push');
+        await hyperlink(
+          {
+            recursive: true,
+            root: 'https://example.com/',
+            inputUrls: ['https://example.com/']
+          },
+          t
+        );
+
+        expect(t.push, 'to have a call satisfying', () => {
+          t.push(null, {
+            operator: 'fragment-redirect',
+            name:
+              'fragment-redirect https://example.com/ --> https://example.com/subdir#myFragment --> https://example.com/subdir/',
+            at:
+              'https://example.com/ (1:50) <a href="/subdir#myFragment">...</a>',
+            ok: false
+          });
+        });
+      });
+
+      it('should complain about a fragment href pointing to a page that is redirected, even though there is a trailing slash and the fragment exists', async function() {
+        httpception([
+          {
+            request: 'GET https://example.com/',
+            response: {
+              headers: {
+                'Content-Type': 'text/html'
+              },
+              body: `<!DOCTYPE html><html><head></head><body><a href="/subdir/#myFragment"></a></body></html>`
+            }
+          },
+          {
+            request: 'GET https://example.com/subdir/',
+            response: {
+              statusCode: 302,
+              headers: {
+                Location: 'https://example.com/subdir2/'
+              }
+            }
+          },
+          {
+            request: 'GET https://example.com/subdir2/',
+            response: {
+              headers: {
+                'Content-Type': 'text/html'
+              },
+              body: `<!DOCTYPE html><html><head></head><body><div id="myFragment"></div></body></html>`
+            }
+          }
+        ]);
+
+        const t = new TapRender();
+        sinon.spy(t, 'push');
+        await hyperlink(
+          {
+            recursive: true,
+            root: 'https://example.com/',
+            inputUrls: ['https://example.com/']
+          },
+          t
+        );
+
+        expect(t.push, 'to have a call satisfying', () => {
+          t.push(null, {
+            operator: 'fragment-redirect',
+            name:
+              'fragment-redirect https://example.com/ --> https://example.com/subdir/#myFragment --> https://example.com/subdir2/',
+            at:
+              'https://example.com/ (1:50) <a href="/subdir/#myFragment">...</a>',
+            ok: false
+          });
+        });
+      });
+    });
+
     it('should not complain about an #iefix fragment in a CSS file', async function() {
       const t = new TapRender();
       sinon.spy(t, 'push');
@@ -796,7 +961,7 @@ describe('hyperlink', function() {
             ok: false,
             operator: 'fragment-check',
             name:
-              'fragment-check testdata/fragmentIdentifier/index.html --> /subdir#definitely-broken',
+              'fragment-check testdata/fragmentIdentifier/index.html --> /subdir/#definitely-broken',
             expected: 'id="definitely-broken"'
           });
         }).and('to have no calls satisfying', () => {

--- a/testdata/fragmentAndRedirectWithSlash/index.html
+++ b/testdata/fragmentAndRedirectWithSlash/index.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head></head>
+<body>
+  <a href="/subdir/#myFragment"></a>
+</body>
+</html>

--- a/testdata/fragmentAndRedirectWithSlash/subdir/index.html
+++ b/testdata/fragmentAndRedirectWithSlash/subdir/index.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head></head>
+<body>
+  <div id="myFragment"></div>
+</body>
+</html>

--- a/testdata/fragmentAndRedirectWithoutSlash/index.html
+++ b/testdata/fragmentAndRedirectWithoutSlash/index.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head></head>
+<body>
+  <a href="/subdir#myFragment"></a>
+</body>
+</html>

--- a/testdata/fragmentAndRedirectWithoutSlash/subdir/index.html
+++ b/testdata/fragmentAndRedirectWithoutSlash/subdir/index.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head></head>
+<body>
+  <div id="myFragment"></div>
+</body>
+</html>

--- a/testdata/fragmentIdentifier/index.html
+++ b/testdata/fragmentIdentifier/index.html
@@ -5,8 +5,8 @@
   <title>Document</title>
 </head>
 <body>
-  <a href="/subdir#fine"></a>
+  <a href="/subdir/#fine"></a>
 
-  <a href="/subdir#definitely-broken"></a>
+  <a href="/subdir/#definitely-broken"></a>
 </body>
 </html>


### PR DESCRIPTION
... except through a FileRedirect (implicit += /index.html) with a trailing slash on the href.

https://github.com/webpack/webpack.js.org/pull/3332#issue-332087335