### PR TITLE
Add 'pretty'-option that lets hyperlink sresolve extensionless hrefs …

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -39,6 +39,13 @@ const commandLineOptions = optimist
     describe: 'Only check links to assets within your own web root',
     type: 'boolean',
   })
+  .options('pretty', {
+    alias: 'p',
+    describe:
+      'Resolve "pretty" urls without .html extension to the .html file on disk',
+    type: 'boolean',
+    default: false,
+  })
   .options('source-maps', {
     describe:
       'Verify the correctness of links to source map files and sources.',
@@ -144,6 +151,7 @@ t.pipe(process.stdout);
         followSourceMaps: followSourceMaps,
         recursive: commandLineOptions.recursive,
         internalOnly: commandLineOptions.internal,
+        pretty: commandLineOptions.pretty,
         skipFilter,
         todoFilter,
         verbose: commandLineOptions.verbose,

--- a/lib/index.js
+++ b/lib/index.js
@@ -59,6 +59,8 @@ function returnFalse() {
  * @param  {Function} [options.skipFilter] Filter function to mark failed tests as [skipped](https://testanything.org/tap-version-13-specification.html#skipping-tests). Return a `String` to add a message or `true` to just mark as skipped
  * @param  {Function} [options.todoFilter] Filter function to mark failed tests as [todo](https://testanything.org/tap-version-13-specification.html#todo-tests)'s. Return a `String` to add a message or `true` to just mark as todo
  * @param  {Boolean} [options.recursive = false] Recurse onto other pages within the root parameters origin
+ * @param  {Boolean} [options.internalOnly = false] Only check links to assets within your own web root
+ * @param  {Boolean} [options.pretty = false] Resolve extensionless links to their corresponding .html-file on disk
  * @param  {Boolean} [options.followSourceMaps = false] Check source maps
  * @param  {Boolean} [options.verbose = false] Verbose output from AssetGraph
  * @param  {Boolean} [options.memdebug = false] Memory debugging
@@ -75,6 +77,7 @@ async function hyperlink(
     todoFilter = returnFalse,
     recursive = false,
     internalOnly = false,
+    pretty = false,
     followSourceMaps = false,
     verbose = false,
     memdebug = false,
@@ -431,10 +434,12 @@ async function hyperlink(
   const entrypoints = [...assetQueue];
 
   const processedAssets = new Set();
+  const processedUrls = new Set();
   // eslint-disable-next-line no-inner-declarations
   async function processAsset(asset) {
-    if (!processedAssets.has(asset)) {
+    if (!processedUrls.has(asset.urlOrDescription)) {
       processedAssets.add(asset);
+      processedUrls.add(asset.urlOrDescription);
 
       const loadReport = {
         operator: 'load',
@@ -460,12 +465,40 @@ async function hyperlink(
           ok: true,
         });
       } catch (err) {
-        reportTest({
+        const failedLoadReport = {
           ...loadReport,
           ok: false,
           actual: err.message,
-        });
-        return;
+        };
+
+        // If configured, check for extensionless html file links.
+        // Some web serves are configured to resolve these automatically
+        if (
+          pretty &&
+          !entrypoints.includes(asset) &&
+          asset.protocol === 'file:' &&
+          asset.extension !== '.html'
+        ) {
+          const originalUrl = asset.url;
+
+          try {
+            asset.fileName += '.html';
+            await asset.load();
+
+            reportTest({
+              ...loadReport,
+              ok: true,
+            });
+            asset.url = originalUrl;
+          } catch (err) {
+            reportTest(failedLoadReport);
+            asset.url = originalUrl;
+            return;
+          }
+        } else {
+          reportTest(failedLoadReport);
+          return;
+        }
       }
 
       if (asset.isRedirect) {

--- a/test/index.js
+++ b/test/index.js
@@ -2838,6 +2838,62 @@ describe('hyperlink', function () {
     });
   });
 
+  describe('pretty-url feature', () => {
+    it('should resolve html files on disk from urls without .html extension', async function () {
+      const t = new TapRender();
+      sinon.spy(t, 'push');
+      await hyperlink(
+        {
+          recursive: true,
+          root: pathModule.resolve(__dirname, '..', 'testdata', 'pretty-url'),
+          inputUrls: ['index.html'],
+          pretty: true,
+        },
+        t
+      );
+
+      expect(t.close(), 'to satisfy', {
+        count: 5,
+        pass: 5,
+        fail: 0,
+        skip: 0,
+        todo: 0,
+      });
+      expect(t.push, 'to have a call satisfying', () => {
+        t.push({
+          name: 'Crawling 0 outgoing urls',
+        });
+      });
+    });
+
+    it('should fail to resolve html files on disk from urls without .html extension', async function () {
+      const t = new TapRender();
+      sinon.spy(t, 'push');
+      await hyperlink(
+        {
+          recursive: true,
+          root: pathModule.resolve(__dirname, '..', 'testdata', 'pretty-url'),
+          inputUrls: ['index.html'],
+          pretty: false,
+        },
+        t
+      );
+
+      expect(t.close(), 'to satisfy', {
+        count: 5,
+        pass: 3,
+        fail: 2,
+        skip: 0,
+        todo: 0,
+      });
+      expect(t.push, 'to have a call satisfying', () => {
+        t.push({
+          name: 'Crawling 0 outgoing urls',
+        });
+      });
+    });
+  });
+
   it('should resolve local srcset images as internal', async function () {
     const t = new TapRender();
     sinon.spy(t, 'push');

--- a/testdata/preconnect/existing/index.html
+++ b/testdata/preconnect/existing/index.html
@@ -1,6 +1,9 @@
 <html>
+
 <head>
-    <link rel="preconnect" href="https://google.com/">
+  <link rel="preconnect" href="https://cloudflare.com/">
 </head>
+
 <body></body>
+
 </html>

--- a/testdata/pretty-url/extensionless.html
+++ b/testdata/pretty-url/extensionless.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Document</title>
+</head>
+
+<body>
+  <h1>Extensionless page</h1>
+</body>
+
+</html>

--- a/testdata/pretty-url/folder/index.html
+++ b/testdata/pretty-url/folder/index.html
@@ -1,0 +1,1 @@
+This is a page

--- a/testdata/pretty-url/index.html
+++ b/testdata/pretty-url/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Document</title>
+</head>
+
+<body>
+  <a href="extensionless">link to page, with .html file-extension missing. Should resolve to extenstionless.html</a>
+  <a href="version-1.0.0">version link ending with dots that confuse the extension. Should resolve to
+    version-1.0.0.html</a>
+  <a href="folder/">folder link without file name. Shoudl resolve to folder/index.html</a>
+</body>
+
+</html>

--- a/testdata/pretty-url/version-1.0.0.html
+++ b/testdata/pretty-url/version-1.0.0.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Document</title>
+</head>
+
+<body>
+  <h1>Version 1.0.0</h1>
+</body>
+
+</html>


### PR DESCRIPTION
…to html files

It seems some hosts, netlify among them, will allow to link to html-files wihtout their `.html` extensions, thus allowing for pretty urls. Hyperlink couldn't resolve this. 

Case in point: I wanted to test the https://github.com/eslint/website website and couldn't

Relates to https://github.com/Munter/netlify-plugin-checklinks/issues/62