### PR TITLE
Use FileRedirect relations for the pretty feature

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -481,20 +481,27 @@ async function hyperlink(
         ) {
           const originalUrl = asset.url;
 
-          try {
-            asset.fileName += '.html';
-            await asset.load();
-
-            reportTest({
-              ...loadReport,
-              ok: true,
+          const prettyUrl = asset.url.replace(/(\?|#|$)/, '.html$1');
+          let prettyAsset = ag.findAssets({ url: prettyUrl })[0];
+          if (!prettyAsset) {
+            prettyAsset = ag.addAsset({
+              url: prettyUrl,
             });
-            asset.url = originalUrl;
+          }
+          try {
+            await prettyAsset.load();
+            asset.isRedirect = true;
+            asset.fileRedirectTargetUrl = prettyUrl;
           } catch (err) {
             reportTest(failedLoadReport);
-            asset.url = originalUrl;
             return;
           }
+
+          reportTest({
+            ...loadReport,
+            ok: true,
+          });
+          asset.url = originalUrl;
         } else {
           reportTest(failedLoadReport);
           return;

--- a/test/index.js
+++ b/test/index.js
@@ -2893,8 +2893,8 @@ describe('hyperlink', function () {
       );
 
       expect(t.close(), 'to satisfy', {
-        count: 5,
-        pass: 5,
+        count: 7,
+        pass: 7,
         fail: 0,
         skip: 0,
         todo: 0,
@@ -2930,6 +2930,30 @@ describe('hyperlink', function () {
         t.push({
           name: 'Crawling 0 outgoing urls',
         });
+      });
+    });
+
+    // Regression test for https://github.com/Munter/hyperlink/issues/182
+    it('should not break when discovering a second pretty link to a page that has already been processed', async function () {
+      const t = new TapRender();
+      sinon.spy(t, 'push');
+      await hyperlink(
+        {
+          recursive: true,
+          root: pathModule.resolve(
+            __dirname,
+            '..',
+            'testdata',
+            'prettyUrlIssue182'
+          ),
+          inputUrls: ['index.html'],
+          pretty: true,
+        },
+        t
+      );
+
+      expect(t.close(), 'to satisfy', {
+        fail: 0,
       });
     });
   });

--- a/testdata/prettyUrlIssue182/index.html
+++ b/testdata/prettyUrlIssue182/index.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+<head>
+</head>
+<body>
+  <a href="/set-designer">Set Designer</a>
+</body>
+</html>

--- a/testdata/prettyUrlIssue182/set-designer.html
+++ b/testdata/prettyUrlIssue182/set-designer.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+<head>
+</head>
+<body>
+  <a href="/set-designer">Set Designer</a>
+</body>
+</html>


### PR DESCRIPTION
Prevents an already visited asset from receiving a `-1` suffix because it's moved out of the way.

Fixes #182