### PR TITLE
Avoid ever following JavascriptFetch relations. Fixes #188

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -678,6 +678,8 @@ async function hyperlink(
           if (followSourceMaps) {
             relation.to.check = true;
           }
+        } else if (relation.type === 'JavaScriptFetch') {
+          follow = false;
         } else {
           follow = true;
         }

--- a/test/index.js
+++ b/test/index.js
@@ -2983,4 +2983,25 @@ describe('hyperlink', function () {
       todo: 0,
     });
   });
+
+  it('should not follow JavaScriptFetch relations', async function () {
+    const t = new TapRender();
+    sinon.spy(t, 'push');
+    await hyperlink(
+      {
+        recursive: false,
+        root: pathModule.resolve(__dirname, '..', 'testdata', 'fetch'),
+        inputUrls: ['index.html'],
+      },
+      t
+    );
+
+    expect(t.close(), 'to satisfy', {
+      count: 1,
+      pass: 1,
+      fail: 0,
+      skip: 0,
+      todo: 0,
+    });
+  });
 });

--- a/testdata/fetch/index.html
+++ b/testdata/fetch/index.html
@@ -1,0 +1,3 @@
+<script>
+  fetch('./foo.json').then(console.log);
+</script>


### PR DESCRIPTION
After discussion in https://github.com/Munter/hyperlink/issues/188 we came to the agreement that following `JavaScriptFetch` relations was not desirable.

For the few cases where it is used to fetch an internal static resource, the user can use Assetgraph's `'/path/to/data.json'.toString('url')` annotation to make the string itself a relation