### PR TITLE
Make it clearer that --skip and --todo are substrings

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -53,13 +53,14 @@ const commandLineOptions = yargs
     default: false,
   })
   .options('skip', {
-    describe: 'Avoid running a test where the report matches the given pattern',
+    describe:
+      'Avoid running a test where the report matches the given pattern (case-sensitive substring match)',
     type: 'string',
     demand: false,
   })
   .options('todo', {
     describe:
-      'Mark a failed tests as todo where the report matches the given pattern',
+      'Mark a failed test as todo where the report matches the given pattern (case-sensitive substring match)',
     type: 'string',
     demand: false,
   })


### PR DESCRIPTION
This tripped me up – I implicitly read "pattern" as "regexp pattern" and padded my skip pattern with `.*` and it didn't quite work...